### PR TITLE
Fix Policies.ps1, CIPOlicy.ps1 and use Drivers directory + style fixes

### DIFF
--- a/Windows 10 Build/Scripts/Audit.ps1
+++ b/Windows 10 Build/Scripts/Audit.ps1
@@ -10,7 +10,9 @@ Push-Location -Path $PSScriptRoot
 $payload = $PSScriptRoot
 
 #Install the latest Windows Defender Update if supplied in the Payload folder
- if (Test-Path -Path $payload\mpam-fe.exe) {Start-Process -FilePath $payload\mpam-fe.exe -Wait}
+if (Test-Path -Path $payload\mpam-fe.exe) {Start-Process -FilePath $payload\mpam-fe.exe -Wait}
 
 #Execute the OEM powershell script to allow OEM software applications, utilities, and OS configuration to take place.
 Invoke-Expression $payload\OEM_Audit.ps1
+
+Pop-Location

--- a/Windows 10 Build/Scripts/BuildWinPE.ps1
+++ b/Windows 10 Build/Scripts/BuildWinPE.ps1
@@ -8,18 +8,18 @@ $sources = (Get-Item -Path "..\Source" -Verbose).FullName
 $images = (Get-Item -Path ".\..\Images" -Verbose).FullName
 $deliverables = (Get-Item -Path "..\Deliverable" -Verbose).FullName
 
-function Import-Environment
+function Import-Environment 
 {
-param(
-[parameter(mandatory=$true)]
-[string]$batch
-)
-$dump = cmd /c "`"$batch`" 1>nul && set"
-$dump |%{
-$s = $_ -split '='
-Write-Verbose ("Var {0} = {1}" -f $s[0],$s[1])
-[System.Environment]::SetEnvironmentVariable($s[0],$s[1])
-}
+    param(
+        [parameter(mandatory=$true)]
+        [string]$batch
+    )
+    $dump = cmd /c "`"$batch`" 1>nul && set"
+    $dump | ForEach-Object {
+        $s = $_ -split '='
+        Write-Verbose ("Var {0} = {1}" -f $s[0],$s[1])
+        [System.Environment]::SetEnvironmentVariable($s[0],$s[1])
+    }
 }
 
 #Cleanup the source folders in case a previous WInPE is present
@@ -38,6 +38,9 @@ Copy-Item -Path $builddir\Scripts\Deploy.bat -Destination $mount\Windows\System3
 Copy-Item -Path $builddir\Scripts\Capture.bat -Destination $mount\Windows\System32
 Copy-Item -Path $builddir\Scripts\Diskpart-Deploy.txt -Destination $mount\Windows\System32\Diskpart.txt
 
+#Add any drivers available in Build\Drivers
+Add-WindowsDriver -Path $mount -Driver $drivers -Recurse
+
 #Unmount %mount% /commit
 Dismount-WindowsImage -Path $mount -Save
 
@@ -54,5 +57,4 @@ Copy-Item -Path $builddir\Scripts\startnet-recover.cmd -Destination $mount\Windo
 #Unmount %mount% /commit
 Dismount-WindowsImage -Path $mount -Save
 
-
-
+Pop-Location

--- a/Windows 10 Build/Scripts/CleanupDeployment.ps1
+++ b/Windows 10 Build/Scripts/CleanupDeployment.ps1
@@ -1,2 +1,2 @@
-﻿Remove-Item $env:SystemDrive\Payload\* -Recurse -Force -ErrorAction SilentlyContinue
+﻿Remove-Item $env:SystemDrive\Payload -Recurse -Force -ErrorAction SilentlyContinue
         

--- a/Windows 10 Build/Scripts/CreateCIPOlicy.ps1
+++ b/Windows 10 Build/Scripts/CreateCIPOlicy.ps1
@@ -10,14 +10,14 @@ $EnforcedCIPolicy=$CIPolicyPath+"EnforcedPolicy.xml"
 
 $EnforcedCIPolicyBin=$CIPolicyPath+"EnforcedDeviceGuardPolicy.bin"
 
-New-CIPolicy -Level PcaCertificate -Fallback Hash -FilePath $InitialCIPolicy –UserPEs 3> CIPolicyLog.txt
+New-CIPolicy -Level PcaCertificate -Fallback Hash -FilePath $InitialCIPolicy -UserPEs 3> CIPolicyLog.txt
 
 ConvertFrom-CIPolicy $InitialCIPolicy $CIPolicyBin
 
 Set-RuleOption -FilePath $InitialCIPolicy -Option 9
 Set-RuleOption -FilePath $InitialCIPolicy -Option 10
 
-Copy $InitialCIPolicy $EnforcedCIPolicy
+Copy-Item $InitialCIPolicy $EnforcedCIPolicy
 
 Set-RuleOption -FilePath $EnforcedCIPolicy -Option 3 -Delete
 

--- a/Windows 10 Build/Scripts/CreateProductionImageMedia.ps1
+++ b/Windows 10 Build/Scripts/CreateProductionImageMedia.ps1
@@ -25,6 +25,7 @@ $deliverables = (Get-Item -Path "..\Deliverable" -Verbose).FullName
 
 #Cleanup the output folders
 Remove-Item -Path $images\Deployment.wim -Force -ErrorAction SilentlyContinue
+Remove-Item -Path $images\Deployment-Optimized.wim -Force -ErrorAction SilentlyContinue
 Remove-Item -Path $deliverables\USB\* -Recurse -Force -ErrorAction SilentlyContinue
 Remove-Item -Path $deliverables\ISO\* -Recurse -Force -ErrorAction SilentlyContinue
 
@@ -77,4 +78,5 @@ Copy-Item -Path $sources\WinPE\media\* -Destination $deliverables\USB -Recurse -
 
 #Run oscdimg against  %builddir%\Deliverable\USB with output to %builddir%\Deliverable\ISO
 Start-Process -FilePath $builddir\Scripts\MakeBaseISO.bat -Wait -WindowStyle Hidden -PassThru
-cd $builddir
+
+Pop-Location

--- a/Windows 10 Build/Scripts/EnablePolicies.ps1
+++ b/Windows 10 Build/Scripts/EnablePolicies.ps1
@@ -1,6 +1,9 @@
 ﻿#Enables IoT Specific policies. Uncomment and needed policies. Each policy has a description of what is does and the value being set.
 #The commands are disabled by default. Uncomment the commands to enable policies as needed.
 
+Push-Location -Path $PSScriptRoot
+$payload = $PSScriptRoot
+
 #Set Windows Defender policies. The policies set are:
 #Computer
 #SOFTWARE\Policies\Microsoft\Windows Defender\Scan
@@ -72,7 +75,7 @@
 #SignatureUpdateCatchupInterval
 #DWORD:30
 
-#Start-Process -FilePath "$env:SystemDrive\Payload\Payload\LGPO\LGPO.exe" -ArgumentList "/m $env:SystemDrive\Payload\Payload\DefenderSettings.pol" -WindowStyle Hidden -Wait
+#Start-Process -FilePath "$payload\LGPO\LGPO.exe" -ArgumentList "/m $payload\Policies\DefenderSettings.pol" -WindowStyle Hidden -Wait
 
 #Set Delivery Optimization policies. The policies set are:
 #Computer
@@ -80,7 +83,7 @@
 #DODownloadMode
 #DWORD:0
 
-#Start-Process -FilePath "$env:SystemDrive\Payload\Payload\LGPO\LGPO.exe" -ArgumentList "/m $env:SystemDrive\Payload\Payload\DeliveryOptimization.pol" -WindowStyle Hidden -Wait
+#Start-Process -FilePath "$payload\LGPO\LGPO.exe" -ArgumentList "/m $payload\Policies\DeliveryOptimization.pol" -WindowStyle Hidden -Wait
 
 #Set Smart Screen policies. The policies set are:
 #Computer
@@ -88,7 +91,7 @@
 #EnableSmartScreen
 #DWORD:0
 
-#Start-Process -FilePath "$env:SystemDrive\Payload\Payload\LGPO\LGPO.exe" -ArgumentList "/m $env:SystemDrive\Payload\Payload\DisableSmartScreen.pol" -WindowStyle Hidden -Wait
+#Start-Process -FilePath "$payload\LGPO\LGPO.exe" -ArgumentList "/m $payload\Policies\DisableSmartScreen.pol" -WindowStyle Hidden -Wait
 
 #Set Windows Updates notification level to disabled
 #Computer
@@ -101,6 +104,6 @@
 #UpdateNotificationLevel
 #DWORD:2
 
-#Start-Process -FilePath "$env:SystemDrive\Payload\Payload\LGPO\LGPO.exe" -ArgumentList "/m $env:SystemDrive\Payload\Payload\SetUpdateNotificationLevel.pol" -WindowStyle Hidden -Wait
+#Start-Process -FilePath "$payload\LGPO\LGPO.exe" -ArgumentList "/m $payload\Policies\SetUpdateNotificationLevel.pol" -WindowStyle Hidden -Wait
 
-
+Pop-Location

--- a/Windows 10 Build/Scripts/EnableSecurityBaseline.ps1
+++ b/Windows 10 Build/Scripts/EnableSecurityBaseline.ps1
@@ -14,3 +14,5 @@ $sec_baseline_script = (Get-Item -Path ".\PreInstall\Windows-10-RS1-and-Server-2
 # Install the Windows 10 Security baseline on the machine. Note, there is an error created when piping in the character to start the script. 
 # The error can be ignored and the baseline is being applied correctly.
 "X" | cmd /c $sec_baseline_script
+
+Pop-Location

--- a/Windows 10 Build/Scripts/EnableTrafficBaseline.ps1
+++ b/Windows 10 Build/Scripts/EnableTrafficBaseline.ps1
@@ -11,3 +11,5 @@ $traffic_baseline_script = (Get-Item -Path ".\PreInstall\Restricted Traffic Limi
 # Install the Restricted Traffic Limited Functionality Baseline. Note, there is an error created when piping in the character to start the script. 
 # The error can be ignored and the baseline is being applied correctly.
 "X" | cmd /c $traffic_baseline_script
+
+Pop-Location

--- a/Windows 10 Build/Scripts/OEM_Audit.ps1
+++ b/Windows 10 Build/Scripts/OEM_Audit.ps1
@@ -3,6 +3,9 @@
 Push-Location -Path $PSScriptRoot
 $payload = $PSScriptRoot
 
+Write-Host "OEM Audit Script"
+Start-Sleep -Milliseconds 5000
+
 #Execute the EnablePolicies.ps1 powershell script to enable IoT specific policies.
 #Invoke-Expression $payload\EnablePolicies.ps1
 
@@ -12,6 +15,6 @@ $payload = $PSScriptRoot
 #Execute the EnableTrafficBaseline.ps1 powershell script to apply the Windows 10 Restricted Traffic Limited Functionality Baseline.
 #Invoke-Expression $payload\EnableTrafficBaseline.ps1
 
-Write-Host "OEM Audit Script"
-Start-Sleep -Milliseconds 5000
+Write-Host "Finished OEM Audit Script"
 
+Pop-Location

--- a/Windows 10 Build/Scripts/OEM_OOBE.ps1
+++ b/Windows 10 Build/Scripts/OEM_OOBE.ps1
@@ -1,5 +1,10 @@
 ﻿#The OEM_OOBE script is called by OOBE.ps1 to install any OEM customizations during the OOBE phase.
-
+Push-Location -Path $PSScriptRoot
+$payload = $PSScriptRoot
 
 Write-Host "OEM OOBE Script"
 Start-Sleep -Milliseconds 5000
+
+Write-Host "Finished OEM OOBE Script"
+
+Pop-Location

--- a/Windows 10 Build/Scripts/OOBE.ps1
+++ b/Windows 10 Build/Scripts/OOBE.ps1
@@ -6,6 +6,9 @@
 
 ############################################
 
+Push-Location -Path $PSScriptRoot
+$payload = $PSScriptRoot
+
 ##Script Functions
 
 ## For test purposes of the script
@@ -64,14 +67,16 @@ Add-Type @"
   }
 "@
 
-$parent = Get-Process -id ((gwmi win32_process -Filter "processid='$pid'").parentprocessid)
-If ($parent.Name -eq "cmd") {# Being run by via cmd prompt (batch file)
-    $h = (Get-Process cmd).MainWindowHandle
-    [void] [Tricks]::SetForegroundWindow($h)
+    $parent = Get-Process -id ((Get-WmiObject win32_process -Filter "processid='$pid'").parentprocessid)
+    If ($parent.Name -eq "cmd") # Being run by via cmd prompt (batch file)
+    {
+        $h = (Get-Process cmd).MainWindowHandle
+        [void] [Tricks]::SetForegroundWindow($h)
     }
-    else{# being run in powershell ISE or console
-          $h = (Get-Process -id $pid).MainWindowHandle
-          [void] [Tricks]::SetForegroundWindow($h)
+    else # being run in powershell ISE or console
+    {
+        $h = (Get-Process -id $pid).MainWindowHandle
+        [void] [Tricks]::SetForegroundWindow($h)
     }
 } 
 
@@ -87,7 +92,7 @@ Write-Host "Please wait while the OOBE post deployment script completes."
 Get-Focus
 
 #Install the latest Windows Defender Update if supplied in the Payload folder
- if (Test-Path -Path $payload\mpam-fe.exe) {Start-Process -FilePath $payload\mpam-fe.exe -Wait}
+if (Test-Path -Path $payload\mpam-fe.exe) {Start-Process -FilePath $payload\mpam-fe.exe -Wait}
 
 #Execute the OEM powershell script to allow OEM software applications, utilities, and OS configuration to take place.
 Invoke-Expression $payload\OEM_OOBE.ps1

--- a/Windows 10 Build/Scripts/SetupEnvironment.ps1
+++ b/Windows 10 Build/Scripts/SetupEnvironment.ps1
@@ -18,7 +18,7 @@ New-Item -Path ..\. -Name "Cumulative Updates" -ItemType directory
 
 #Remove the mark of the web from the deployment framework files
 #Remove the mark of the web from the deployment framework files
-Get-Item * -Stream "Zone.Identifier" -ErrorAction SilentlyContinue | ForEach {Unblock-File $_.FileName}
+Get-Item * -Stream "Zone.Identifier" -ErrorAction SilentlyContinue | ForEach-Object {Unblock-File $_.FileName}
 
 
 

--- a/Windows 10 Build/Scripts/Sysprep.ps1
+++ b/Windows 10 Build/Scripts/Sysprep.ps1
@@ -1,7 +1,6 @@
 ﻿#Sysprep script 
 
 Push-Location -Path $PSScriptRoot
-
 $payload = $PSScriptRoot
 
 #Clear the product key 


### PR DESCRIPTION
- Policies.ps1 referred to non-existing directory + policies weren't copied to the Payload directory
- Add drivers in the Drivers to the WinPE and the base image
- Has corrupted character instead of '-'  leading to undefined behavior
- Add 'Pop-Location' to scripts where Push-Location is used
- Let CreateProductionImageMedia.ps1 return to where you started

This is a culmination of changes I made during Windows prototyping the past few weeks.