### PR TITLE
Push SetupEnvironment.ps1 script location

### DIFF
--- a/Windows 10 Build/Scripts/SetupEnvironment.ps1
+++ b/Windows 10 Build/Scripts/SetupEnvironment.ps1
@@ -1,5 +1,7 @@
 #SetupEnvironment will create the directories expected by the build framework and remove the mark of the web from the scripts
 
+Push-Location -Path $PSScriptRoot
+
 New-Item -Path ..\. -Name Source -ItemType directory
 New-Item -Path ..\.\Source -Name ISO -ItemType directory
 New-Item -Path ..\. -Name Payload -ItemType directory


### PR DESCRIPTION
`SetupEnvironment.ps1` creates directories in the parent directory of the current working directory.  If it's run from a directory other than a subdirectory of the builddir, it will create directories in the wrong
location.  Call Push-Location to avoid this.