### PR TITLE
Set $payload in OOBE.ps1

### DIFF
--- a/Windows 10 Build/Scripts/OOBE.ps1
+++ b/Windows 10 Build/Scripts/OOBE.ps1
@@ -81,6 +81,8 @@ If ($parent.Name -eq "cmd") {# Being run by via cmd prompt (batch file)
 
 ##Script init
 
+$payload = $PSScriptRoot
+
 Write-Host "Please wait while the OOBE post deployment script completes."
 
 #Set Focus on the script to accept input


### PR DESCRIPTION
OOBE.ps1 uses $payload but doesn't set it.  This causes the commands which use $payload to fail.  Ensure that it is set.